### PR TITLE
Treat 0.0.0.0 and :: like loopback addresses

### DIFF
--- a/syntaxes/hosts.tmLanguage
+++ b/syntaxes/hosts.tmLanguage
@@ -28,7 +28,7 @@
       <key>comment</key>
       <string>Loopback address like 127.0.0.1</string>
       <key>match</key>
-      <string> *127(\.((25[0-5])|(2[0-4][0-9])|(1[0-9][0-9])|([1-9][0-9])|[0-9])){3}|::1</string>
+      <string> *127(\.((25[0-5])|(2[0-4][0-9])|(1[0-9][0-9])|([1-9][0-9])|[0-9])){3}|0\.0\.0\.0|::1?</string>
       <key>name</key>
       <string>support.type.built-in.loopback.hosts</string>
     </dict>


### PR DESCRIPTION
[`0.0.0.0`](https://en.wikipedia.org/wiki/0.0.0.0) and [`::`](https://en.wikipedia.org/wiki/0.0.0.0#In_IPv6).